### PR TITLE
Kleine Korrekturen und duplizierte Aufgabe entfernt

### DIFF
--- a/i1gem.tex
+++ b/i1gem.tex
@@ -28,7 +28,7 @@ Menge Vitamin A kann für jede Art Essen bestimmt werden, etc.
 
 In der Einleitung war die Rede von Papageien:\index{Papagei} die benutzen wir, um
 gemischte Daten einzuführen.  Vorher müssen wir jedoch Papageien mit den bekannten
-Mitteln definieren; wir versuchen es, kurz und schmerzlos zu machen:
+Mitteln definieren; wir versuchen, es kurz und schmerzlos zu machen:
 
 Wir interessieren uns vor allem für sprechende Papageien.  Genau wie
 bei Gürteltieren interessiert uns das Gewicht, aber wir nehmen an, da
@@ -108,7 +108,7 @@ Schablone:
 
 \end{verbatim}
 %
-Fertig!  Sie können sich vielleicht vorstellen, daß  Papageien und
+Fertig!  Sie können sich vielleicht vorstellen, dass  Papageien und
 Gürteltiere sich in einem Programm begegnen, also \emph{gemischt}
 vorkommen.  Papageien und Gürteltiere gehören zum gemeinsamen
 Oberbegriff \textit{Tier}\index{Tier}, den wir im Rahmen eines solchen
@@ -253,7 +253,7 @@ gemischte Daten.  Zunächst zur Daten- und Signaturdefinition:
 \end{itemize}
 %
 Eine Schablone für eine Prozedur und deren Testfälle, die gemischte
-Daten akzeptiert, können Sie folgendermaßen konzentrieren:
+Daten akzeptiert, können Sie folgendermaßen konstruieren:
 %
 \begin{itemize}
 \item Schreiben Sie Tests für jeden der Fälle.
@@ -280,7 +280,7 @@ des entsprechenden Falls.
 Beachten Sie den Unterschied zwischen \texttt{one-of} und
 \texttt{mixed}, die leicht zu verwechseln sind: \texttt{One-of} steht
 für "`einer der folgenden \emph{Werte}"', während \texttt{mixed} für
-"`gehörend zu einer der folgenden \emph{Signaturen}"' gehört.
+"`gehörend zu einer der folgenden \emph{Signaturen}"' steht.
 
 \section{Die Zucker-Ampel}
 
@@ -374,8 +374,8 @@ annehmen:
           traffic-light)))
 \end{verbatim}
 %
-Das Beispiel zeigt, daß die Fälle einer Definition für gemischte Daten
-nicht allesamt Records sein müssen.  Es ist allerdings wichtig, daß
+Das Beispiel zeigt, dass die Fälle einer Definition für gemischte Daten
+nicht allesamt Records sein müssen.  Es ist allerdings wichtig, dass
 die Fälle \emph{disjunkt} sind, also jeder Wert eindeutig einem der
 Fälle zugeordnet werden kann: Sonst wäre es nicht möglich, eine sinnvolle
 Verzweigung zu schreiben, welche die Fälle unterscheidet.
@@ -634,22 +634,22 @@ Fertig!
   \begin{itemize}
   \item Essen - Beschrieben durch einen Namen, den Stückpreis, das Mindesthaltbarkeitsdatum
     und den aktuellen Bestand im Supermarkt.
-  \item Getränke - Beschrieben durch einen Namen, den Stückpreis, das Mindesthaltbarkeitsdatum,
+  \item Getränke - Beschrieben durch einen Namen, den Stückpreis, das Mindesthaltbarkeitsdatum
     und den Bestand. Zusätzlich muss hier noch festgehalten werden, ob Pfand verlangt wird.
   \item Sonstige - Beschrieben durch einen Namen, den Stückpreis und den Bestand.
   \end{itemize}
 
   
   \begin{enumerate}
-  \item Führen sie eine Datenanalyse durch und erstellen sie Daten- und 
+  \item Führen Sie eine Datenanalyse durch und erstellen Sie Daten- und 
     Record-Definitionen.
-  \item Schreiben sie eine Prozedur \texttt{stückpreis}, die eine Warenklasse
+  \item Schreiben Sie eine Prozedur \texttt{stückpreis}, die eine Warenklasse
     konsumiert und den Stückpreis zurückgibt.
-  \item Schreiben sie eine Prozedur \texttt{buchen}, die  eine Warenklasse und die Anzahl der
-    abzubuchenden Exemplare	konsumiert, den Bestand der Warenklasse reduziert und die
+  \item Schreiben Sie eine Prozedur \texttt{buchen}, die eine Warenklasse und die Anzahl der
+    abzubuchenden Exemplare konsumiert, den Bestand der Warenklasse reduziert und die
     Warenklasse zurückgibt. Falls mehr Exemplare gefordert werden, als in der Warenklasse
     vorhanden sind, soll der Bestand auf 0 gesetzt werden.
-  \item Schreiben sie eine Prozedur \texttt{haltbar?}, die eine
+  \item Schreiben Sie eine Prozedur \texttt{haltbar?}, die eine
     Warenklasse und ein Datum konsumiert und \texttt{\#t} zurückgibt, falls das
     Mindesthaltbarkeitsdatum (MHD) nicht überschritten wurde. Falls kein MHD bekannt ist,
     soll \texttt{\#t} zurückgeben werden.
@@ -703,7 +703,7 @@ Fertig!
     % \end{figure}
 
   \item Es soll Prozeduren geben, die auf allen Formen funktionieren
-    und folgendes leisten:
+    und Folgendes leisten:
 
     \begin{itemize}
 

--- a/i1hop.tex
+++ b/i1hop.tex
@@ -281,7 +281,7 @@ Das funktioniert tatsächlich:
 %
 Das Abstrahieren über Prozeduren funktioniert also genauso wie die
 Abstraktion über andere Werte.  Die Signatur für die Prozedur muß
-natürlich berücksichtigen, daß \texttt{p?} eine Prozedur ist.  Die Prozedur
+natürlich berücksichtigen, dass \texttt{p?} eine Prozedur ist.  Die Prozedur
 \texttt{plays-nürnberg?}, die für \texttt{p?}  verwendet wird, hat die
 Signatur
 %
@@ -292,12 +292,12 @@ Signatur
 und deshalb hat \texttt{filter-games} folgende Signatur:
 %
 \begin{alltt}
-(: filter-games ((game -> boolean) list(game) -> list(game)))
+(: filter-games ((game -> boolean) (list-of game) -> (list-of game)))
 \end{alltt}
 %
 Tatsächlich steht aber in \texttt{filter-games} außer dem Namen dieser Prozedur
 jetzt nichts mehr, das
-überhaupt Bezug darauf nimmt, daß es sich bei den Listenelementen um
+überhaupt Bezug darauf nimmt, dass es sich bei den Listenelementen um
 \texttt{game}-Records handelt.  % Tatsächlich funktioniert die Prozedur
 % auch auf Listen von Zahlen:
 % %
@@ -318,7 +318,7 @@ namens \texttt{list-filter}:\index{filter@\texttt{list-filter}}
 ; aus einer Liste eine Liste der Elemente bilden,
 ; die eine bestimmte Eigenschaft haben
 (: list-filter ((%a -> boolean) (list-of %a) -> (list-of %a)))
-(define filter
+(define list-filter
   (lambda (p? lis)
     (cond
       ((empty? lis) empty)
@@ -760,7 +760,7 @@ liefert, läßt sich auch auf andere Prozeduren anwenden:\index{make-mult@\texttt{
       (* a b))))
 
 ; Prozedur erzeugen, die an eine Liste ein Element vorn anhängt
-(: make-prepend (a -> (list(a) -> list(a))))
+(: make-prepend (a -> ((list-of a) -> (list-of a))))
 (define make-prepend
   (lambda (a)
     (lambda (b)
@@ -797,6 +797,7 @@ Mathematikern \textsc{Moses Schönfinkel} und \textsc{Haskell Curry} entdeckt.  I
 englischsprachigen Raum heißt das Verb dazu darum  \textit{currify}, im deutschsprachigen Raum
 \textit{schönfinkeln\index{schönfinkeln}}
 oder \textit{curryfizieren\index{curryfizieren}}.
+% Warum heißt dann die Funktion dann curry und nicht currify?
 
 Die Schönfinkel-Transformation läßt sich auch umdrehen:\index{curry@\texttt{curry}}
 %

--- a/i1list.tex
+++ b/i1list.tex
@@ -76,7 +76,7 @@ gibt.  Diese folgt in wenigen Augenblicken.
 Ein Paar kann nun benutzt werden, um die letzte Liste aus der obigen
 Tabelle zu repräsentieren.  "`Pumps"' wird als Zeichenkette zum ersten
 Element des Paars.  Die \texttt{rest}-Komponente des Paars muß eine
-Liste sein~-- dabei ist zu beachten, daß insbesondere die leere Liste
+Liste sein~-- dabei ist zu beachten, dass insbesondere die leere Liste
 eine Liste ist, dort also verwendet werden kann:
 %
 \begin{alltt}
@@ -151,7 +151,7 @@ entspricht damit nicht der gängigen Intuition, wie Listen aufgebaut
 sind, aber es funktioniert.  Für viel mehr als drei Elemente
 funktioniert die Darstellungsweise allerdings nicht: Darum bevorzugen
 wir ab hier sogenannte "`Zeigerdiagramme"', bei denen alle Paare gleich groß
-dargestellt sind und ein Pfeil zeigt, daß ein Paar die
+dargestellt sind und ein Pfeil zeigt, dass ein Paar die
 \texttt{rest}-Komponente eines anderen Paares bildet.
 Abbildung~\ref{fig:pair-lists-2} zeigt das Pfeildiagramm, das
 Abbildung~\ref{fig:pair-lists-1} entspricht; es paßt besser zur
@@ -297,7 +297,7 @@ Beispiellisten folgende Werte:
 \evalsto{} 2
 \end{alltt}
 %
-Das ist jeweils das \emph{erste Element}~-- kein Wunder, daß der
+Das ist jeweils das \emph{erste Element}~-- kein Wunder, dass der
 Selektor \texttt{first}\index{first@\texttt{first}} heißt.  Nun für \texttt{rest}\index{rest@\texttt{rest}}:
 %
 \begin{alltt}
@@ -345,7 +345,7 @@ Das können wir in die Schablone von oben einsetzen:
 %
 Dieses Programm ist nicht nur vollständig, es funktioniert auch
 tatsächlich: Alles was wir gemacht haben war, die Kurzbeschreibung
-von \texttt{list-sum} ernst zu nehmen, die behauptet, daß die Prozedur
+von \texttt{list-sum} ernst zu nehmen, die behauptet, dass die Prozedur
 die Summe einer beliebigen Liste berechnet: \texttt{(rest lis)} ist
 eine Liste, also kann \texttt{list-sum} auch deren Summe berechnen.
 
@@ -413,7 +413,7 @@ zur Verfügung:
 %
 Der \texttt{empty}-Testfall ist vielleicht etwas verwirrend: In der
 Tat sind alle Elemente der leeren Liste positiv.  Eine andere Art dies
-zu sagen wäre, daß kein Element der leeren Liste nicht positiv ist.
+zu sagen wäre, dass kein Element der leeren Liste nicht positiv ist.
 
 Diese Testfälle reichen sichtlich nicht aus, da alle \verb|#t| ergeben
 sollen: Diese würden auch von folgender Prozedur erfüllt:
@@ -485,7 +485,7 @@ von derselben Sorte.  Es gibt eine Liste von Essenszutaten, eine von
 Eigennamen, eine von Zahlen, eine von dramatischen Figuren, eine von
 Frisuren und eine von Schuhen.  Die Datendefinition für
 \texttt{a-list} von Seite~\ref{def:a-list} ist da allerdings nicht
-festgelegt: es heißt ausdrücklich, daß jedes Paar ein
+festgelegt: es heißt ausdrücklich, dass jedes Paar ein
 \emph{beliebiges} Element enthält.  So ist beispielsweise auch
 folgende Liste zulässig:
 %
@@ -496,7 +496,7 @@ folgende Liste zulässig:
 %
 In den meisten Fällen gehören jedoch alle Elemente einer Liste zu
 derselben Sorte beziehungsweise haben dieselbe Signatur: Schön wäre
-es, wenn die Signatur für die Liste dokumentieren könne, welche
+es, wenn die Signatur für die Liste dokumentieren könnte, welche
 Signatur die Elemente haben.  Wir könnten bei
 der Definition von \texttt{pair} die Signatur der Elemente angeben,
 also \texttt{pair} zum Beispiel auf Elemente der Signatur
@@ -522,7 +522,7 @@ nicht mehr \texttt{a-list} sondern \texttt{list-of-numbers} nennen:\index{list-o
           pair)))
 \end{verbatim}
 %
-Das funktioniert zwar, hat aber den Nachteil, daß wir dann für jede
+Das funktioniert zwar, hat aber den Nachteil, dass wir dann für jede
 neue Elementsorte eine neue Definition von Listen schreiben müssen:
 \texttt{list-of-strings}, \texttt{list-of-shoes} etc.  Das wäre nicht
 nur mühsam, sondern würde auch viel Code ohne Sinn und Verstand
@@ -587,7 +587,7 @@ Hier sind  \verb|%a| und \verb|%b| wiederum
 \textit{Signaturvariablen}, die für beliebige
 Signaturen stehen.  Die Tatsache, dass hier zwei verschiedene Signaturvariablen
 verwendet wurden bringt die zusätzliche Information für den
-menschlichen Leser zum Ausdruck, daß die
+menschlichen Leser zum Ausdruck, dass die
 Argumente von \texttt{pair-of} zu potentiell
 unterschiedlichen Signaturen gehören.
 
@@ -606,7 +606,7 @@ Zu lesen sind die obigen Signaturdeklarationen so:
 %
 
 Diese Signaturen sind allerdings noch unbefriedigend, da sie nicht zum
-Ausdruck bringen, daß das zweite Argument von \texttt{make-pair} immer
+Ausdruck bringen, dass das zweite Argument von \texttt{make-pair} immer
 eine \emph{Liste} sein muß beziehungsweise daß \texttt{rest} immer
 eine Liste liefert.  Diese Problematik stellen wir noch einen Moment
 hintenan, werden aber später zu ihr zurückkehren~-- zunächst einmal zu
@@ -816,10 +816,10 @@ Als Testfall kann obige Beispielliste herhalten:
 %
 \begin{verbatim}
 (check-expect (run-over-dillos dl75)
-	      (list (make-dillo 55000 #f)
-		    d2
-		    (make-dillo 60000 #f)
-		    d4))
+              (list (make-dillo 55000 #f)
+                    d2
+                    (make-dillo 60000 #f)
+                    d4))
 \end{verbatim}
 %
 Zur Erinnerung: \texttt{d2} und \texttt{d4} sind bereits tot,
@@ -888,8 +888,8 @@ Wir müssen also nur die Resultate der beiden Ausdrucke mit
 %
 Fertig!
 
-Dieses Beispiel zeigt, daß wir für Prozeduren, die Listen produzieren,
-keine neue Technik brauchen: Wenn eine Prozedure eine leere Liste
+Dieses Beispiel zeigt, dass wir für Prozeduren, die Listen produzieren,
+keine neue Technik brauchen: Wenn eine Prozedur eine leere Liste
 produzieren soll, benutzen wir an der entsprechenden Stelle
 \texttt{empty}, und bei nichtleeren Listen benutzen wir
 \texttt{make-pair}, bringen also die Schablone für Prozeduren zum
@@ -1045,92 +1045,6 @@ Schreiben Sie folgende Prozeduren auf Listen:
 \end{aufgabe}
 
 \begin{aufgabe}
-   In einem Fischnetz landen~--- vereinfacht
-  dargestellt~--- Fische, Quallen und Schuhe.  Ein Fischerreigut ist
-  also ein Fisch, eine Qualle oder ein Schuh.  Jedes dieser
-  Fischerreigüter hat ein Gewicht in Gramm; Fische besitzen außerdem
-  zusätzlich noch die Eigenschaft, ob sie essbar sind oder nicht (und
-  daher aussortiert werden müssen); Qualen können giftig sein. 
-  Schreiben Sie ein Programm für
-  einen Fischsortierer, der die essbaren Fische aus den
-  Fischerreigütern herausfiltern kann.
-
-  \begin{enumerate}
-  \item Führen Sie eine Datenanalyse für
-    Fischerreigüter durch und schreiben Sie passende Daten- und
-    Recorddefinitionen.  Geben Sie ein paar Beispiele für
-    Fischerreigüter an, die Sie in den nächsten Teilaufgaben in
-    Testfällen verwenden können.
-
-  \item Schreiben Sie eine Prozedur
-    \texttt{edible-fish?}, die überprüft ob ein übergebenes
-    Fischerreigut ein essbarer Fisch ist.
-
-  \item Schreiben Sie eine Prozedur \texttt{weight}, 
-    die das Gewicht eines beliebigen Fischerreiguts zurückgibt.
-
-  \item Schreiben Sie eine Daten- und Recorddefinition
-    für Listen von Fischerreigütern.  Geben Sie alle Signaturen an!
-    Geben Sie außerdem mindestens fünf verschiedene Beispiele für Listen
-    mit Fischerreigütern an.
-
-  \item Schreiben Sie eine Prozedur \texttt{total-weight},
-    die eine Liste von Fischerreigütern akzeptiert und das Gesamtgewicht
-    aller Fischerreigüter in der Liste ausrechnet.
-
-  \item Schreiben Sie eine Prozedur
-    \texttt{total-edible-fish-weight}, die eine Liste von 
-    Fischerreigüter akzeptiert und das Gesamtgewicht aller 
-    essbaren Fische in der Liste ausrechnet.
-
-  \item Schreiben Sie eine Prozedur \texttt{count}, die 
-    eine Liste von Fischerreigütern akzeptiert und die Anzahl der
-    Fischerreigüter in der Liste bestimmt.
-
-  \item Schreiben Sie eine Prozedur
-    \texttt{count-edible-fish}, die eine Liste von
-    Fischerreigütern akzeptiert und die Anzahl der essbaren
-    Fische in der Liste bestimmt.
-
-  \item Ein Sortierer soll nun die Fische 
-    aus dem Fischernetz automatisch sortieren. Leider ist der Sortierer 
-    sehr alt und kommt deswegen mit großen Quallen und Schuhen nicht 
-    klar.  Der Sortiervorgang wird abgebrochen, sobald eine Qualle oder ein
-    Schuh, der schwerer als 1kg ist, in den Sortierer gerät.
-    Schreiben Sie die Prozedur \texttt{fish-sorter}, die diesen Vorgang
-    simuliert. Als Eingabe bekommt diese Prozedur eine Liste von
-    Fischerreigütern, die sie nach und nach abarbeitet.
-    Herauskommen soll eine Liste von Fischerreigütern, in der die
-    gefischten essbaren Fische enthalten sind.  Schreiben Sie
-    ausreichend Testfälle, beachten Sie auch den Fall, dass der
-    Sortierer im Leerlauf betrieben wird.  Verwenden Sie die Prozeduren
-    aus den vorherigen Aufgabenteilen.
-
- \item Schreiben Sie eine Prozedur
-   \texttt{heaviest-fish}, die aus einer Liste von Fischerreigütern
-   den schwersten essbaren Fisch heraussucht und zurückgibt.  Wenn in
-   der Liste kein essbarer Fisch enthalten ist, soll die Prozedur
-   \verb|#f| zurückgeben.
-
- \item Schreiben Sie eine Prozedur
-   \texttt{filter-edible-potatoes}, die eine Liste von
-   Ackerbestandteilen akzeptiert und die essbaren Kartoffeln als Liste
-   zurückgibt.
-   
- \item Schreiben Sie eine Prozedur
-   \texttt{drop-stones}, die eine Liste von Ackerbestandteilen
-   akzeptiert und eine Liste zurückgibt, in der es keine Steine mehr
-   gibt.
-
- \item Schreiben Sie eine Prozedur
-   \texttt{average-weight-edible-potatoes}, die eine Liste von
-   Ackerbestandteilen akzeptiert und das durchschnittliche Gewicht
-   der essbaren Kartoffeln berechnet.
-  \end{enumerate}
-  
-\end{aufgabe}
-
-\begin{aufgabe}
    Auf einem Acker gibt es ~--- vereinfacht
   dargestellt~--- Kartoffeln, Erdklumpen und Steine.  Ein
   Ackerbestandteil ist also eine Kartoffel, ein Erdklumpen oder ein
@@ -1148,7 +1062,7 @@ Schreiben Sie folgende Prozeduren auf Listen:
     Testfällen verwenden können.
 
   \item Schreiben Sie eine Prozedur
-    \texttt{edible-potatoe?}, die überprüft ob ein übergebener
+    \texttt{edible-potato?}, die überprüft ob ein übergebener
     Ackerbestandteil eine essbare Kartoffel ist.
 
   \item Schreiben Sie eine Prozedur \texttt{weight}, 
@@ -1207,10 +1121,10 @@ Schreiben Sie folgende Prozeduren auf Listen:
       akzeptiert und eine Liste zurückgibt, in der es keine Steine mehr
       gibt.
 
-    \item (BONUSAUFGABE) Schreiben Sie eine Prozedur
+    \item Schreiben Sie eine Prozedur
       \texttt{average-weight-edible-potatoes}, die eine Liste von
       Ackerbestandteilen akzeptiert und das durchschnittliche Gewicht
-      der essbaren Kartoffel berechnet.
+      der essbaren Kartoffeln berechnet.
 
   \end{enumerate}
   

--- a/i1prog.tex
+++ b/i1prog.tex
@@ -153,7 +153,7 @@ Programm schreiben:
 \end{alltt}
 %
 Diese Bilder sind Werte wie Zahlen und Zeichenketten auch.
-Insbesondere können Sie mit Definitionen an Namen gebunden werden:
+Insbesondere können sie mit Definitionen an Namen gebunden werden:
 %
 \begin{verbatim}
 (define s1 (square 40 "solid" "slateblue"))
@@ -183,12 +183,12 @@ Eine Definition wie
 (define mehrwertsteuer 19)
 \end{alltt}
 %
-suggeriert, daß die Zahl 19 an dieser Stelle eine Bedeutung "`in der
+suggeriert, dass die Zahl 19 an dieser Stelle eine Bedeutung "`in der
 realen Welt"' hat, zum Beispiel in einem Programm, das eine Registrierkasse
 steuert oder das bei der Steuererklärung hilft.  Die Bedeutung könnte
 folgende Aussage sein: "`Der Mehrwertsteuersatz beträgt 19\%."'
 Dieser Satz repräsentiert \textit{Information}\index{Information},
-also ein Fakt über die Welt oder zumindest den Ausschnitt der Welt, in
+also einen Fakt über die Welt oder zumindest den Ausschnitt der Welt, in
 dem das Programm arbeiten soll.  In Computerprogrammen wird
 Information in eine vereinfachte Form gebracht, mit der das Programm
 rechnen kann~-- in diesem Fall die Zahl 19.  Diese vereinfachte Form
@@ -216,7 +216,7 @@ wieder klarstellen müssen, wie Information in Daten zu übersetzen ist
 und umgekehrt.
 
 Manche Programme können auch Informationen direkt verarbeiten, meist
-dadurch, daß sie diese erst in Daten übersetzen und dann die Daten
+dadurch, dass sie diese erst in Daten übersetzen und dann die Daten
 weiterverarbeiten.  Der Teil, der diese Übersetzung leistet, heißt
 \textit{Benutzerschnittstelle}\index{Benutzerschnittstelle}.  Zunächst
 werden wir uns allerdings primär mit rein datenverarbeitenden
@@ -270,7 +270,7 @@ in einen Ausdruck verwandeln können:
 Um zu den Ausdrücken zu kommen, welche die Anzahl der PKWs ausrechnen,
 haben wir sogenanntes \textit{Domänenwissen}\index{Domänenwissen}
 benutzt: Die "`Domäne"' der Aufgabe sind PKWs und Motorräder, und wir
-wissen, daß PKWs jeweils vier Räder und Motorräder zwei haben.
+wissen, dass PKWs jeweils vier Räder und Motorräder zwei haben.
 Schließlich haben wir noch Algebra benutzt, um aus dem Domänenwissen
 eine Formel zu machen.
 
@@ -311,7 +311,7 @@ obigen Ausdrücke können auch folgendermaßen geschrieben werden:
 %
 Daß die \texttt{2} jetzt jeweils in einer weiteren Zeile steht, läßt
 die Ausdrücke so ähnlich aussehen wie der Bruch in der Formel.  Die
-Einrückung vor der \texttt{2} macht klar, daß die \texttt{2} noch in
+Einrückung vor der \texttt{2} macht klar, dass die \texttt{2} noch in
 die Klammern vom \texttt{/} gehört.
 
 Wir als Programmierer müssen uns selbst darum kümmern, an sinnvollen
@@ -378,8 +378,8 @@ DrRacket auch aus:
 #<procedure>
 \end{alltt}
 %
-Für sich genommen macht eine Prozedur noch nichts interessantes.  Sie kann jedoch
-\emph{angewendet} werden, was heißt, das konkrete Werte für $m$ und
+Für sich genommen macht eine Prozedur noch nichts Interessantes.  Sie kann jedoch
+\emph{angewendet} werden, was heißt, dass konkrete Werte für $m$ und
 $n$ eingesetzt werden:
 %
 \begin{alltt}
@@ -395,7 +395,7 @@ $n$ eingesetzt werden:
 (lambda (\(p\sb{1} \ldots p\sb{n}\)) \(e\))
 \end{alltt}
   %
-  Die $p_i$ jeweils Namen, die \textit{Parameter}\index{Parameter} und
+  Die $p_i$ sind jeweils Namen, die \textit{Parameter}\index{Parameter}, und
   $e$ ist der \textit{Rumpf}\index{Rumpf}.  In $e$ dürfen die $p_i$
   vorkommen.  Der Wert einer Abstraktion ist eine \textit{Prozedur}\index{Prozedur},
   welche für jeden Parameter eine Eingabe erwartet.
@@ -418,7 +418,7 @@ Abbildung~\ref{scheme:abstraction} erklärt die beiden Konzepte
 "`Abstraktion"' und "`Anwendung"' im allgemeinen.
 
 Bisher ist jedoch noch nicht viel gewonnen, weil wir den
-$lambda$-Ausdruck jedesmall wiederholen mußten.  Da er jedoch beide
+$lambda$-Ausdruck jedesmal wiederholen mußten.  Da er jedoch beide
 Male genau gleich ist, können wir ihm mit \texttt{define} einen Namen
 geben:
 %
@@ -577,7 +577,7 @@ nur für Prozeduren.  Zum Beispiel so:
 %
 Bei \texttt{parking-lot-cars} ist die Signatur noch nicht besonders
 umfangreich oder kompliziert.
-Spätere Kapitel werden zeigen, daß sich aus vielen Signaturen ganz
+Spätere Kapitel werden zeigen, dass sich aus vielen Signaturen ganz
 automatisch \textit{Schablonen\index{Schablone}} ergeben, die dem
 Programmierer einen Großteil der Denkarbeit bei der Entwicklung von
 Prozeduren abnehmen.
@@ -644,10 +644,10 @@ Tätigkeit des Programmierers.
 
 Die Testfälle werden am besten \emph{vor} der Definition der Prozedur
 aufgestellt, denn  wenn sie erst hinterher geschrieben werden, ist die
-Gefahr groß, daß unbewußt das tatsächliche Ergebnis
+Gefahr groß, dass unbewußt das tatsächliche Ergebnis
 eines Prozeduraufrufs als das gewünschte eingegeben oder besonders
 kritische Beispiele weggelassen werden.  (In der industriellen Praxis ist sogar
-oft üblich, daß jemand anderes als der Autor der Definitionen
+oft üblich, dass jemand anderes als der Autor der Definitionen
 die Testfälle schreibt.)
 
 Es ist mühselig, bei der Programmentwicklung ständig Testfälle in die
@@ -668,7 +668,7 @@ tatsächlichen Ergebnisse der Ausdrücke mit den Soll-Werten
 mit Informationen über die Unterschiede zwischen erwarteten und
 tatsächlichen Ergebnissen; ansonsten gibt es eine kurze Meldung, dass die
 Testfälle erfolgreich waren.  Für die obere inkorrekte Version kommt
-zum Beispiel folgendes heraus:
+zum Beispiel Folgendes heraus:
 %
 \begin{alltt}
 3 Tests gelaufen.

--- a/i1rekzahlen.tex
+++ b/i1rekzahlen.tex
@@ -86,7 +86,7 @@ einfacher zu ergänzen: hier ist nämlich die Konstruktionsanleitung für
 zusammengesetzte Daten anwendbar.  Als Selektor wird die
 Vorgängeroperation angewendet, es steht also \texttt{(- n 1)} in der
 Alternative.
-Genau wie bei den endlichen Folgen liegt nahe, daß auf \texttt{(- n 1)} ein
+Genau wie bei den endlichen Folgen liegt nahe, dass auf \texttt{(- n 1)} ein
 rekursiver Aufruf erfolgt:
 %
 \begin{alltt}
@@ -129,7 +129,7 @@ Substitutionsmodell ergibt:
 \(\Longrightarrow\) (* 1 ...)
 \end{alltt}
 %
-Damit ist klar, daß die unbekannte Zahl, die an Stelle der 
+Damit ist klar, dass die unbekannte Zahl, die an Stelle der 
 \texttt{...} stehen muß, multipliziert mit 1 wiederum 1 ergeben muß.
 Die einzige Zahl, die diese Bedingung erfüllt, ist 1 selbst.  Die
 vollständige Definition von \texttt{factorial} ist also:
@@ -175,7 +175,7 @@ Die typischen Beobachtungen an diesem Beispiel sind:
 \begin{itemize}
 \item \texttt{Factorial} ruft sich nie mit derselben Zahl $n$ auf, mit
   der es selbst aufgerufen wurde, sondern immer mit $n-1$.
-\item Die natürlichen Zahlen sind so strukturiert, daß die Kette $n,
+\item Die natürlichen Zahlen sind so strukturiert, dass die Kette $n,
   n-1, n-2 \ldots$ irgendwann bei $0$ abbrechen muß.
 \item \texttt{Factorial} ruft sich bei $n=0$ \emph{nicht}
   selbst auf.
@@ -207,7 +207,7 @@ TDB: Prozeduren, die Listen erzeugen etc.
 \section*{Aufgaben}
 
 \begin{aufgabe}\label{aufg:power}
-  Schreibe eine Prozedur \texttt{power}, die für eine Basis $b$ und
+  Schreiben Sie eine Prozedur \texttt{power}, die für eine Basis $b$ und
   einen Exponenten $e\in\mathbb{N}$ die Potenz $b^e$ ausrechnet.  Also:
 \begin{alltt}
 (power 5 3)
@@ -221,7 +221,7 @@ TDB: Prozeduren, die Listen erzeugen etc.
     Die eingebaute Prozedur \texttt{even?}\index{even?@\texttt{even?}}
     akzeptiert eine ganze Zahl und liefert \verb|#t|, falls diese
     gerade ist und \verb|#f| sonst.
-    Schreibe mit Hilfe von \texttt{even?}
+    Schreiben Sie mit Hilfe von \texttt{even?}
     eine Prozedur namens \texttt{evens}, welche für zwei
     Zahlen $a$ und $b$ eine Liste der geraden Zahlen zwischen $a$ und
     $b$ zurückgibt:
@@ -237,8 +237,8 @@ TDB: Prozeduren, die Listen erzeugen etc.
     Die eingebaute Prozedur \texttt{odd?}\index{odd?@\texttt{odd?}}
     akzeptiert eine ganze Zahl und liefert \verb|#t|, falls diese
     ungerade ist und \verb|#f| sonst.
-    Schreibe mit Hilfe von \texttt{odd?} eine Prozedur \texttt{odds}, welche für zwei Zahlen
-    $a$ und $b$ eine Liste die ungeraden Zahlen zwischen $a$ und $b$
+    Schreiben Sie mit Hilfe von \texttt{odd?} eine Prozedur \texttt{odds}, welche für zwei
+    Zahlen $a$ und $b$ eine Liste der ungeraden Zahlen zwischen $a$ und $b$
     zurückgibt:
 \begin{alltt}
 (odds 1 10)
@@ -306,7 +306,7 @@ TDB: Prozeduren, die Listen erzeugen etc.
 \end{aufgabe}
 
 \begin{aufgabe}\label{ex:coke-finances}
-  Schreibe eine Prozedur \texttt{drink-machine}, die das
+  Schreiben Sie eine Prozedur \texttt{drink-machine}, die das
   Finanzmanagement eines Getränkeautomaten durchführt.
   
   \texttt{Drink-machine} soll drei Argumente akzeptieren: den Preis eines
@@ -321,7 +321,7 @@ TDB: Prozeduren, die Listen erzeugen etc.
 \begin{alltt}
 (drink-machine 140 (list 50 100 500 10 10) 200)
 \evalsto{} #<list 50 10>
-(check-expect (drink-machine 140 (list 50 20 20 20) 200) (list 20 20 20))
+(drink-machine 140 (list 50 20 20 20) 200)
 \evalsto{} #<list 20 20 20>
 \end{alltt}
 \end{aufgabe}

--- a/i1verzw.tex
+++ b/i1verzw.tex
@@ -976,18 +976,18 @@ wenn die Auswertung einen Fehler liefert:
     Gefährdungslage mehr, gibt Punkte und Fahrverbote. Schreiben Sie
     zwei Prozeduren, eine für das Bußgeld \texttt{rote-ampel-bußgeld}, 
     eine für die Punkte in Flensburg \texttt{rote-ampel-punkte} 
-    und eine für das Fahrverbot \texttt{rote-ampel-fahrverbot} 
-    welche ausgibt ob ein Fahrverbot erteilt wird. Übergeben
+    und eine für das Fahrverbot \texttt{rote-ampel-fahrverbot}, 
+    welche ausgibt, ob ein Fahrverbot erteilt wird. Übergeben
     Sie den Prozeduren, wie lange die Ampel schon rot war und ob eine
     Gefährdung oder Sachbeschädigung vorlag.
     
     Die Bußgelder sind wie folgend definiert:
     \begin{itemize}
     \item Bei Rot über die Ampel innerhalb der ersten Sekunde			
-      \euro{50} und 3 Punkte
+      \euro{50} und 3 Punkte.
     \item Bei Rot über die Ampel innerhalb der ersten Sekunde mit
       Gefährdung oder Sachbeschädigung \euro{125}, 4 		
-      Punkte und 1 Monat Fahrverbot
+      Punkte und 1 Monat Fahrverbot.
     \item Bei Rot über die Ampel nach der ersten Sekunde \euro{125},
       4 Punkte und 1 Monat Fahrverbot.
     \item Bei Rot über die Ampel nach der ersten Sekunde mit

--- a/i1zus.tex
+++ b/i1zus.tex
@@ -8,11 +8,11 @@
 TBD
 
 Mit anderen Worten: mehrere Dinge werden \emph{zu einem}
-zusammengesetzt.  Eine andere Betrachtungsweise ist, daß ein einzelnes
+zusammengesetzt.  Eine andere Betrachtungsweise ist, dass ein einzelnes
 Ding durch mehrere Eigenschaften charakterisiert ist.
 
 In Scheme lassen sich solche \textit{zusammengesetzte
-Daten}\index{zusammengesetzte Daten} durch
+Daten}\index{zusammengesetzten Daten} durch
 \textit{Records}\index{Record} darstellen.  Ein Record ist wie ein
 Behälter mit mehreren Fächern, in denen die Bestandteile der Daten
 untergebracht sind.
@@ -41,7 +41,7 @@ Ein Computer\index{Computer} \emph{besteht aus}:
 Natürlich besteht ein Computer auch noch aus anderen Teilen, die
 aber (zumindest in diesem Beispiel) immer gleich sind.  In einer Bestellung muß
 der Kunde also nur diese drei Bestandteile angeben.  Wir nehmen an,
-daß es beim Prozessor nur auf den Namen ("`Athlon"', "`Xeon"',
+dass es beim Prozessor nur auf den Namen ("`Athlon"', "`Xeon"',
 "`Cell"', \ldots) ankommt, beim RAM nur auf die Größe in Gigabyte, und
 auch bei der Festplatte nur auf die Größe in Gigabyte.  Eine
 vereinfachte Darstellung könnte so aussehen:
@@ -178,7 +178,7 @@ Das Gerüst müßte folgendermaßen sein:
 \end{alltt}
 %
 Da in den Gesamtspeicher des Computer sowohl der Hauptspeicher als
-auch die Festplatte eingehen, steht schon fest, daß die
+auch die Festplatte eingehen, steht schon fest, dass die
 entsprechenden Selektoraufrufe im Rumpf der Prozedur vorkommen müssen:
 %
 \begin{alltt}
@@ -199,7 +199,7 @@ Das Gesamtspeicher ergibt sich aus Addition der beiden Komponenten:
 %
 Fertig!
 
-\texttt{Total-memory} ist ein Beispiel für eine Prozedur, die einen
+\texttt{total-memory} ist ein Beispiel für eine Prozedur, die einen
 Record akzeptiert.  Umgekehrt gibt es auch Prozeduren, die Records
 produzieren.  Angenommen, unser Computerhändler bietet neben der
 Einzelkonfiguration von Prozessor, Hauptspeicher und Festplatte einige
@@ -261,7 +261,7 @@ wir dazu \texttt{string=?}:
       ((string=? k "game") ...))))
 \end{verbatim}
 %
-In jedem Zweig müssen wir nun dafür sorgen, daß der entsprechende
+In jedem Zweig müssen wir nun dafür sorgen, dass der entsprechende
 Computer hergestellt wird.  Für das Herstellen von Computer-Records
 ist der Konstruktor \texttt{make-computer} zuständig.  Dementsprechend
 müssen wir in jedem Zweig einen Aufruf an \texttt{make-computer}
@@ -283,7 +283,7 @@ Jetzt müssen wir nur noch die Argumente für die Aufrufe von
 \texttt{make-computer} zur Verfügung stellen.  Für jeden Aufruf sind
 das, wie gehabt, der Prozessor, die Größe des Hauptspeichers und die
 Größe der Festplatte.  Die entsprechenden Angaben können wir zum
-Beispiel den Testfällen entnehmen, und es kommt folgendes dabei heraus:
+Beispiel den Testfällen entnehmen, und es kommt Folgendes dabei heraus:
 %
 \begin{verbatim}
 (define standard-computer
@@ -377,7 +377,7 @@ Insbesondere gehört zu jeder Komponente ein Selektor.
 Die Namen für den Konstruktor, das Prädikat und die Selektoren können
 frei gewählt werden, sollten aber meist einer einheitlichen
 Konvention folgen, um anderen das Lesen des Programms zu erleichern.
-Die gängige Konvention ist, daß der Konstruktor mit \texttt{make-}
+Die gängige Konvention ist, dass der Konstruktor mit \texttt{make-}
 anfängt (\texttt{make-cartesian}), der Name des Prädikats auf ein
 Fragezeichen endet (\texttt{cartesian?}), und die Selektoren mit dem Namen des
 Record-Typs beginnen und auf die
@@ -465,8 +465,8 @@ Datendefinition übersetzen:
 %
 Wiederum handelt es sich sichtlich um zusammengesetzte Daten.  Diesmal
 trifft die Phrase "`besteht aus"' natürlich nicht zu.  Stattdessen
-geht es um die Eigenschaften, von denen ein Gürteltiert viele hat.
-Von diesen vielen interessanten Eigenschaften sind aber viele bei
+geht es um die Eigenschaften, von denen ein Gürteltier viele hat.
+Von diesen vielen interessanten Eigenschaften sind aber etliche bei
 allen Gürteltieren gleich (Säugetier, zwei Augen, vier Füße etc.) und
 darum nicht Teil der Datendefinition.  Für unsere Aufgaben sind
 außerdem nur zwei Eigenschaften von Belang, weshalb die
@@ -628,11 +628,11 @@ Schablone:
     ... (dillo-alive? d) ...))
 \end{verbatim}
 %
-Beim zweiten Testfall haben wir gesehen, daß, was \texttt{feed-dillo}
+Beim zweiten Testfall haben wir gesehen, dass, was \texttt{feed-dillo}
 betrifft, die Gürteltiere in zwei verschiedene Gruppen fallen:
 \texttt{Feed-dillo} verhält sich bei lebenden Gürteltieren anders als
 bei toten: eine Fallunterscheidung.  Entsprechend brauchen wir eine
-Verzweigung im Rumpf.  Da sich der Fall "`Gürteltier tot"' dadurch definiert, daß der
+Verzweigung im Rumpf.  Da sich der Fall "`Gürteltier tot"' dadurch definiert, dass der
 Fall "`Gürteltier lebendig"' nicht eintritt, ist die binäre Verzweigung
 angemessen:
 %
@@ -715,14 +715,14 @@ Fertig!
   \item Schreiben Sie Signatur, Gerüst und Schablone für eine Prozedur,
     die ein Qux konsumiert und eine Zeichenkette zurückgibt.
     Identifizieren Sie die dazu benutzten Konstruktionsanleitungen.
-    Achten Sie darauf, daß Sie auch die Konstruktionsanleitungen für die
+    Achten Sie darauf, dass Sie auch die Konstruktionsanleitungen für die
     Komponenten von Qux-Records zur Anwendung bringen.
   \item Nehmen Sie an, Sie hätten für eine zu schreibende Prozedur
     \texttt{quxop2} die folgende Signatur festgelegt:
 \begin{verbatim}
 (: quxop2 (natural (one-of "Hx" "Bx" "Px") -> qux))
 \end{verbatim}
-    (Dabei ist angenommen, daß die Record-Definition für ein Qux
+    (Dabei ist angenommen, dass die Record-Definition für ein Qux
     den Namen \texttt{qux} hat.) Entwickeln Sie daraus Gerüst und
     Schablone der zu schreibenden Prozedur.  Identifizieren Sie die dazu
     benutzten Konstruktionsanleitungen.
@@ -732,7 +732,7 @@ Fertig!
 
 \begin{aufgabe}
 
-  Schreiben sie ein Programm zur Verwaltung von wöchentlichen
+  Schreiben Sie ein Programm zur Verwaltung von wöchentlichen
   Raumreservierungen an der Uni!
 
   \begin{enumerate}
@@ -838,12 +838,13 @@ Fertig!
 
   \begin{enumerate}
   \item Erstellen Sie eine Datendefinition
-    \texttt{dough} für den Teig.  Jeder Teig besteht aus Eier, Mehl,
+    \texttt{dough} für den Teig.  Jeder Teig besteht aus Eiern, Mehl,
     Zucker und Wasser und hat ein Gesamtgewicht.  Überlegen Sie sich
     geeignete Einheiten für die Zutaten.
+    % In Teil 3. sind allerdings Einheiten angegeben. Absicht?
   \item Erstellen Sie eine Datendefinition \texttt{cake}
     für Kuchen.  Diese enthält einen Teig, eine Backdauer in Minuten und 
-    das Endgewicht des Kuchen.
+    das Endgewicht des Kuchens.
   \item Schreiben Sie eine Prozedur
     \texttt{ingredients->dough} welche eine Anzahl an Eiern, eine
     Menge Mehl in Gramm, eine Menge Zucker in Gramm und eine
@@ -867,20 +868,20 @@ Fertig!
   beziehungsweise Stunde und Minute.
 
   \begin{enumerate}
-  \item Schreiben Sie eine Prozedur \texttt{date-ok?}, die feststellt
+  \item Schreiben Sie eine Prozedur \texttt{date-ok?}, die feststellt,
     ob ein Datums-Objekt einem tatsächlichen Kalenderdatum entspricht,
     also korrekte Daten wie 1.1.1970 von unsinnigen wie 34.17.2006
     unterscheidet. Lassen Sie dazu Schaltjahre außer Acht. Beachten
-    Sie die Monate mit 28, 30 und 31 Monaten.
+    Sie die Monate mit 28, 30 und 31 Tagen.
   \item Schreiben Sie eine Prozedur \texttt{date-equal?}, die
     vergleicht, ob zwei Datums-Objekte gleich sind.
-  \item Schreiben Sie eine Prozedur \texttt{time-ok?}, die feststellt
+  \item Schreiben Sie eine Prozedur \texttt{time-ok?}, die feststellt,
     ob ein Zeit-Objekt einer tatsächlichen Uhrzeit entspricht.
   \item Schreiben Sie eine Prozedur \texttt{time-overlap?}, die
-    überprüft ob sich zwei Zeiten mit einer jeweils gegebenen Dauer
+    überprüft, ob sich zwei Zeiten mit einer jeweils gegebenen Dauer
     (in Minuten) überschneiden. Gehen Sie davon aus, dass es sich um
     Zeiten desselben Tages handelt.
-  \item Schreiben Sie eine Prozedur \texttt{overlap?} die prüft ob
+  \item Schreiben Sie eine Prozedur \texttt{overlap?}, die prüft, ob
     sich zwei gegebene Termine überschneiden. Beachten Sie die Dauer
     der Termine. Gehen Sie davon aus, dass die Termine nicht über
     Mitternacht liegen.
@@ -1206,7 +1207,7 @@ Fertig!
 \begin{aufgabe}
   \label{aufgabe:knaubichler}
   Auf seinen Reisen um die Welt trifft Dr.~Sperber
-  viele interessante und skurille Zeitgenossen. Unter ihnen
+  viele interessante und skurrile Zeitgenossen. Unter ihnen
   Dr.~Knaubichler, ein Experte auf dem Gebiet der Kreuzung von
   mystischen Kreaturen.  Es gibt drei klassische Grundkreaturen:
 
@@ -1234,8 +1235,8 @@ Fertig!
   Grundkreaturen.
 
   Bei der Kreuzung unterschiedlicher Grunkreaturen gilt folgendes:
-  Bei der Kreuzung von Ronugor und Tschipotol
-  das übernommene Wissen um 10\% veringert, bei Tschipotol und
+  Bei der Kreuzung von Ronugor und Tschipotol wird
+  das übernommene Wissen um 10\% veringert; bei Tschipotol und
   Garnolaf hingegen nimmt die Risikobereitschaft um 5\% ab, aber die
   Stärke legt um 8\% zu. Garnolaf und Ronugor lassen die Stärke um 5\%
   zulegen. Kreuzt man alle drei Grundkreaturen, nimmt jede Eigenschaft
@@ -1248,14 +1249,14 @@ Fertig!
   In jedem Fall kann eine Eigenschaft maximal den Wert 100
   haben.
     
-  Dr.~Knaubichler braucht ein Programm, welche die neue Kreatur
+  Dr.~Knaubichler braucht ein Programm, welches die neue Kreatur
   berechnet, bevor er die Kreuzungen durchführt.  Helfen Sie ihm
   dabei!
   
   \begin{enumerate}
 
   \item Machen Sie eine Datenanalyse und erstellen
-    Sie passenden Daten- und Recorddefinitionen.  Geben Sie alle
+    Sie passende Daten- und Recorddefinitionen.  Geben Sie alle
     Signaturen der Record-Prozeduren an!
 
   \item Schreiben Sie für jede der oben aufgelisteten


### PR DESCRIPTION
In den Kapiteln 1 bis 6 und im Kapitel 8 habe ich kleinere Tipp- und sonstige Fehler korrigiert (sowie in Kapiteln, in denen es vermischt war, `daß` durch `dass` ersetzt).

An wenigen Stellen habe ich Kommentare mit Fragen eingefügt.

Aufgabe 5.3 habe ich vollständig entfernt, da sie aus meiner Sicht ein Duplikat der Aufgabe 5.4 mit geänderten Daten ist. Hier passten außerdem die letzten drei Teilaufgaben nicht zur Aufgabe, sondern waren wohl copy/paste von 5.4.