### PR TITLE
add .travis.yml for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+dist: xenial
+all_branches: true
+
+before_install:
+  - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-full
+
+script:
+  - touch includeonly.tex
+  - pdflatex -interaction=nonstopmode -halt-on-error i1
+  - bibtex i1
+  - pdflatex -interaction=nonstopmode -halt-on-error i1
+  - sed -i 's/\\"/"/g' i1.idx
+  - sed -i 's/\\eingebaut/eingebaut/g' i1.idx
+  - makeindex -c -s i1.mst -g i1
+  - pdflatex -interaction=nonstopmode -halt-on-error i1 
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_API_KEY
+  file: i1.pdf
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
  This builds i1.pdf on travis-ci.org and uploads this build artifact to
  github releases if the commit is tagged.

  # Example cli:
  $ git add . && git commit -m "my message"
  $ git tag 2018-11-26
  $ git push origin --tags
  $ git push origin master

  # Example configurations and builds
  https://travis-ci.org/ua74e3dqka/schreibe-dein-programm/builds/459634334
  https://github.com/ua74e3dqka/schreibe-dein-programm/releases/tag/2018-26-11c

  To make this work you need a travis-ci.org account which has at least
  rights to read the repo and deploy the artifact.  Then you need to define
  an environmental variable named GITHUB_API_KEY with the content of
  your OAuth key at GitHub. This prevents leaking the key to a public
  repository.