### PR TITLE
Verwende bereits definierte Funktion, um Signaturverletzung zu zeigen

### DIFF
--- a/i1prog.tex
+++ b/i1prog.tex
@@ -1199,7 +1199,7 @@ Das sehen wir, wenn wir absichtlich einen Fehler wie diesen hier
 machen:
 %
 \begin{verbatim}
-(check-expect (watt-für-wenig "30") 13.0)
+(check-expect (billig-strom "30") 13.0)
 \end{verbatim}
 %
 Probier es aus!  Es erscheint zusammen mit den Meldungen über die


### PR DESCRIPTION
Folgt man den Anweisungen im Buch, so ist Funktion `watt-für-wenig` zu diesem Zeitpunkt noch nicht definiert. (Die Aufgabe https://github.com/deinprogramm/schreibe-dein-programm/blob/e3944895b106d0ce075ce9d66b9bcf75a75b9e79/i1prog.tex#L847-L876 in Abschnitt 1.7 "Programme systematisch konstruieren" dient ja als Beispiel und war vom Leser noch nicht dann als Übungsaufgabe umzusetzen, sondern wurde in den Abschnitten 1.7–1.10 nach und nach bearbeitet: https://github.com/deinprogramm/schreibe-dein-programm/blob/e3944895b106d0ce075ce9d66b9bcf75a75b9e79/i1prog.tex#L877-L1220 – und dort erst für einen der Stromtarife.) Die Funktion `watt-für-wenig` wird wohl erst im darauffolgenden Abschnitt 1.11 "Konstruktionsanleitungen" implementiert: https://github.com/deinprogramm/schreibe-dein-programm/blob/e3944895b106d0ce075ce9d66b9bcf75a75b9e79/i1prog.tex#L1355-L1361

Verwenden wir zur Demonstration einer Signatur-Verletzung daher die bereits in den Abschnitten 1.7–1.10 implementierte Funktion `billig-strom`.