### PR TITLE
rename function "pythagoras" -> "hypothenuse"

### DIFF
--- a/i1prog.tex
+++ b/i1prog.tex
@@ -1700,7 +1700,7 @@ Kapitel~\ref{cha:selbstbezug} auf Seite~\pageref{cha:selbstbezug}.
     \begin{displaymath}
       a^2 + b^2 = c^2
     \end{displaymath}
-    Schreibe eine Funktion \texttt{pythagoras}, die $c$ der
+    Schreibe eine Funktion \texttt{hypotenuse}, die $c$ der
     obigen Gleichung berechnet.  Erkenne und abstrahiere weitere
     Teilprobleme!
 


### PR DESCRIPTION
Just `pythagoras` doesn't indicate what value the function shall compute. [`hypothenuse`](https://en.wikipedia.org/wiki/Hypotenuse) therefore is a more fitting name for it.

I assume the book's target group (CS students at university level) will have heard of that term.