### PR TITLE
 Pythagoras: Hinweis auf Funktion "sqrt" hinzugefügt

### DIFF
--- a/i1prog.tex
+++ b/i1prog.tex
@@ -1702,6 +1702,8 @@ Kapitel~\ref{cha:selbstbezug} auf Seite~\pageref{cha:selbstbezug}.
     \end{displaymath}
     Schreibe eine Funktion \texttt{pythagoras},
     die $c$ der obigen Gleichung berechnet.
+    Um die Quadratwurzel einer Zahl zu berechnen,
+    kannst du \texttt{sqrt} verwenden.
     Erkenne und abstrahiere weitere Teilprobleme!
 
   \item Schreibe schließlich eine Funktion

--- a/i1prog.tex
+++ b/i1prog.tex
@@ -1700,9 +1700,9 @@ Kapitel~\ref{cha:selbstbezug} auf Seite~\pageref{cha:selbstbezug}.
     \begin{displaymath}
       a^2 + b^2 = c^2
     \end{displaymath}
-    Schreibe eine Funktion \texttt{pythagoras}, die $c$ der
-    obigen Gleichung berechnet.  Erkenne und abstrahiere weitere
-    Teilprobleme!
+    Schreibe eine Funktion \texttt{pythagoras},
+    die $c$ der obigen Gleichung berechnet.
+    Erkenne und abstrahiere weitere Teilprobleme!
 
   \item Schreibe schließlich eine Funktion
     \texttt{boat-travel-distance}, die die tatsächliche Strecke


### PR DESCRIPTION
Bei Aufgabe 1.11 Teilaufgabe 3, muss die die Länge der Hypotenuse eines rechtwinkligen Dreiecks aus den Längen der beiden Katheten berechnet werden. Dazu muss eine Quadratwurzel gezogen werden.

Wer schon in anderen Sprachen programmiert hat, wird unschwer erraten können, dass die verwendete Lernsprache oder ihre Standard-Bibliothek eine Funktion mitbringt, die die Quadratwurzel ihres Arguments berechnet, und dass diese `sqrt` (von engl. "square root") heisse könnte. (Denn das ist in allerlei anderen Programmiersprachen auch so.) Da sich das Buch aber auch an Programmier-Anfänger richtet, kann dieses Wissen nicht vorausgesetzt werden, und weder `sqrt` noch, wie man in der Dokumentation nach solchen Funktionen sucht, wurden bis zu dieser Stelle im Buch behandelt, wenn ich mich recht erinnere.

Diese Änderung fügt daher einen kurzen Hinweis auf die Funktion in die Teilaufgabe ein.

Um den inhaltlichen Unterschied (a60179e ) besser erkennbar zu machen, habe ich den LaTeX-Quellcode mit 3f09368 lokal auf [semantic linebreaks](https://rhodesmill.org/brandon/2012/one-sentence-per-line/) umformatiert.