### PR TITLE
Korrektur eines Listings

### DIFF
--- a/i1prog.tex
+++ b/i1prog.tex
@@ -185,7 +185,7 @@ nicht mit Komma geschrieben werden.  Der Überstrich bei
 \textit{Periode\index{Periode}}. Die Zahl ist also eigentlich
 %
 \begin{lstlisting}
-2.9285714285714285714285714285714\ldots
+2.9285714285714285714285714285714|\ldots|
 \end{lstlisting}
 %
 Die REPL funktioniert also folgendermaßen: Sie \emph{liest} einen


### PR DESCRIPTION
In einem Listing hat das escaping für das LaTeX-Makro `\ldots` gefehlt.