### PR TITLE
Fixes müßte(n) --> müsste(n).

### DIFF
--- a/i1lambda.tex
+++ b/i1lambda.tex
@@ -754,7 +754,7 @@ Definition nicht rekursiv ist.
 
 Damit ist zwar die Notation weniger schreibintensiv geworden,
 aber das fundamentale Problem ist noch nicht gelöst: Eine korrekte
-Definition von $\mathit{fac}$ müßte eine unendliche
+Definition von $\mathit{fac}$ müsste eine unendliche
 Kette von Applikationen von $\mathit{FAC}$ enthalten.
 Da sich ein Term mit einer unendlichen Kette von Applikationen nicht aufschreiben läßt, hilft im Moment nur Wunschdenken weiter.
 Dafür sei angenommen, $\mathit{fac}$ wäre bereits gefunden.  Dann gilt folgende

--- a/i1refinement.tex
+++ b/i1refinement.tex
@@ -208,7 +208,7 @@ bereits zwei erkennbare Teilaufgaben:
   einen anderen Baum machen, der das Element nicht mehr enthält.
 \end{enumerate}
 %
-Insbesondere müßte es leicht möglich sein, die zweite Teilaufgabe
+Insbesondere müsste es leicht möglich sein, die zweite Teilaufgabe
 soweit zu lösen, daß die Lösch-Funktion zu zumindest für \texttt{s3}
 funktioniert:
 %
@@ -640,7 +640,7 @@ Es ist sogar möglich, daß Untermieter ihrerseits selbst Untermieter
 haben.  Dieser Idee ließe sich Rechnung tragen, indem eine Wohnung
 statt aus Zimmern aus "<Abschnitten"> besteht, und jeder Abschnitt
 entweder ein Zimmer oder ein untervermieter Wohnungsteil ist.  Die
-Definition für Wohnungen müßte also folgendermaßen geändert werden:
+Definition für Wohnungen müsste also folgendermaßen geändert werden:
 %
 \begin{verbatim}
 ; Eine Wohnung besteht aus:

--- a/i1secd.tex
+++ b/i1secd.tex
@@ -407,7 +407,7 @@ Relation im Sinne einer "<partiellen Funktion"> ist.  Meist wird
 trotzdem von einer Auswertungsfunktion gesprochen.  Beim zweiten
 Haken, wenn $x$ eine Closure ist, läßt sich mit dem Resultat nicht
 viel anfangen: Um die genaue Bedeutung der Closure herauszubekommen,
-müßte sie angewendet werden~-- das Programm ist aber schon fertig
+müsste sie angewendet werden~-- das Programm ist aber schon fertig
 gelaufen.  Es ist also gar nicht sinnvoll, zwischen verschiedenen
 Closures zu unterscheiden.  Darum wird für die Zwecke der
 Auswertungsfunktion eine Menge $Z$ der \textit{Antworten\index{Antwort}}
@@ -2398,7 +2398,7 @@ SECD-Maschine realisiert wird:
 
 \begin{aufgabe}
   \texttt{Begin} läßt sich im angewandten $\lambda$-Kalkül als
-  syntaktischer Zucker auffassen: Wie müßten \texttt{begin}-Ausdrücke
+  syntaktischer Zucker auffassen: Wie müssten \texttt{begin}-Ausdrücke
   in die Sprache des Kalküls übersetzt werden?
 \end{aufgabe}
 

--- a/i1zus.tex
+++ b/i1zus.tex
@@ -224,7 +224,7 @@ Funktionen definieren.
 Für den Anfang könnte das
 eine Funktion sein, die den Gesamtspeicher eines Computers berechnet,
 also Hauptspeicher und Festplattenspeicher zusammen.
-Eine solche Funktion müßte Kurzbeschreibung und Signatur wie folgt
+Eine solche Funktion müsste Kurzbeschreibung und Signatur wie folgt
 haben:\index{total-memory@\texttt{total-memory}} 
 %
 \begin{lstlisting}


### PR DESCRIPTION
Neue deutsche Rechtschreibung.