### PR TITLE
Fixes typo.

### DIFF
--- a/i1zus.tex
+++ b/i1zus.tex
@@ -504,7 +504,7 @@ ergeben sich direkt aus der Record-Definition:
 %
 Der Konstruktor akzeptiert für jedes Feld ein Argument~-- entsprechend
 stehen die Signaturen der Felder vor dem Pfeil.  Heraus kommt beim
-Konstruktor immer ein Record, da steht also der Name des Record-Types.
+Konstruktor immer ein Record, da steht also der Name des Record-Typs.
 
 \begin{feature}{\lstinline{define-record} (einfach)}{scheme:define-record-simple}
 Eine Record-Definition\index{Record-Definition}\index{define-record@\texttt{define-record}}


### PR DESCRIPTION
German Genitive of "Typ" --> "Typs".
Also used in Line 453: "dem Namen des Record-Typs ergibt."