### PR TITLE
Typos verbessern

### DIFF
--- a/i1prog.tex
+++ b/i1prog.tex
@@ -198,7 +198,7 @@ Ausdrücke können auch kombiniert werden, zum Beispiel so:
 |\evalsto| 5166
 \end{lstlisting}
 %
-Bei der Kombination verschiedener Ausdrücker ist es wichtig,
+Bei der Kombination verschiedener Ausdrücke ist es wichtig,
 dass um jeden Teilausdruck wieder ein
 Klammernpaar kommt.  Ist das nicht der Fall, erscheinen gelegentlich
 auch mal Fehlermeldungen wie diese hier:
@@ -357,7 +357,7 @@ Tab-Taste korrekt einrücken.
   Benutze dann die Tab-Taste, um die Einrückung wieder zu korrigieren.
 \end{aufgabeinline}
 %
-Den Inhalt des Definitionsfenster kannst Du abspeichern, indem Du auf
+Den Inhalt des Definitionsfensters kannst Du abspeichern, indem Du auf
 den Knopf mit dem Diskettensymbol
 \raisebox{-1ex}{\includegraphics[height=12pt]{elemente/save}}\footnote{Disketten
 wurden im 20.~Jahrhundert verwendet, um Daten zu speichern.  Es gab
@@ -627,7 +627,7 @@ Dazu schreibst Du es erst einmal genauso hin, also mit \lstinline{a} und
 \lstinline{b}.  Wenn es startet, erscheint folgende Meldung:
 %
 \begin{alltt}
-\color{red}a: Variable nicht definiert
+\color{red}a: Variable ist nicht definiert
 \end{alltt}
 %
 Das bedeutet, dass es keine Definition für \lstinline{a} gibt.

--- a/i1verzw.tex
+++ b/i1verzw.tex
@@ -430,7 +430,7 @@ Kommen wir zur Funktion selbst.  Zunächst einmal das Gerüst:
 \end{lstlisting}
 %
 Da es sich bei der Eingabe um eine Aufzählung, also eine
-Fallunterscheidung handel, brauchen wir eine Verzweigung im Rumpf.  Da
+Fallunterscheidung handelt, brauchen wir eine Verzweigung im Rumpf.  Da
 es drei Fälle in der Aufzählung gibt, braucht die Verzweigung
 ebenfalls drei Zweige:
 %


### PR DESCRIPTION
i1prog.tex, Zeile 630 ist ein ausgelassenes Wort. Mit diesem Pull Request deckt sich die Ausgabe im Buch mit der tatsächlichen Ausgabe von DrRacket. 