### PR TITLE
Verbessere Typo in allen Lizenzheadern

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Wer aktiv am Buch schreibt, mag u.U. ein `includeonly`-Statement in
 
 # Lizenz
 
-Dieses Buch ist lizensiert unter der Creative-Commons-Lizenz
+Dieses Buch ist lizenziert unter der Creative-Commons-Lizenz
 [Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.de).
 

--- a/datenabstraktion.tex
+++ b/datenabstraktion.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1.tex
+++ b/i1.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 
@@ -305,7 +305,7 @@
 Copyright \textcopyright{} 2007-2024 by Michael
   Sperber and Herbert Klaeren
   
-  Dieses Buch ist lizensiert unter der Creative-Commons-Lizenz
+  Dieses Buch ist lizenziert unter der Creative-Commons-Lizenz
   \textit{Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)}, nachzulesen
   unter \url{https://creativecommons.org/licenses/by-sa/4.0/deed.de}.
 \end{titlepage}

--- a/i1akku.tex
+++ b/i1akku.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1gem.tex
+++ b/i1gem.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1hop.tex
+++ b/i1hop.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1indu.tex
+++ b/i1indu.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1lambda.tex
+++ b/i1lambda.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1list.tex
+++ b/i1list.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1pre.tex
+++ b/i1pre.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1prog.tex
+++ b/i1prog.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1prop.tex
+++ b/i1prop.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1refinement.tex
+++ b/i1refinement.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1rek2.tex
+++ b/i1rek2.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1rekzahlen.tex
+++ b/i1rekzahlen.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1secd.tex
+++ b/i1secd.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1selbst.tex
+++ b/i1selbst.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1tree.tex
+++ b/i1tree.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1verzw.tex
+++ b/i1verzw.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.https)"
 % 0://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1vorw.tex
+++ b/i1vorw.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1world.tex
+++ b/i1world.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/i1zus.tex
+++ b/i1zus.tex
@@ -1,4 +1,4 @@
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 

--- a/nachwort.tex
+++ b/nachwort.tex
@@ -1,5 +1,5 @@
 % Diese Datei ist Teil des Buchs "Schreibe Dein Programm!"
-% Das Buch ist lizensiert unter der Creative-Commons-Lizenz
+% Das Buch ist lizenziert unter der Creative-Commons-Lizenz
 % "Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International (CC BY-SA 4.0)"
 % https://creativecommons.org/licenses/by-sa/4.0/deed.de
 


### PR DESCRIPTION
Auf den naheliegenden Fehler "lizensiert" statt "lizenziert" musste ich zuvor auch aufmerksam gemacht werden. :)